### PR TITLE
Refactor/repos

### DIFF
--- a/pkg/gateway/metrics_aggregator.go
+++ b/pkg/gateway/metrics_aggregator.go
@@ -13,12 +13,12 @@ import (
 type MetricsAggregator struct {
 	collectors  map[string]*MetricsCollector // Map of appID to collector
 	mu          sync.RWMutex
-	appStatRepo repository.ApplicationStat
+	appStatRepo *repository.ApplicationStat
 	stopChan    chan struct{}
 	wg          sync.WaitGroup
 }
 
-func NewMetricsAggregator(metricsCollector *MetricsCollector, appStatRepo repository.ApplicationStat) *MetricsAggregator {
+func NewMetricsAggregator(metricsCollector *MetricsCollector, appStatRepo *repository.ApplicationStat) *MetricsAggregator {
 	collectors := make(map[string]*MetricsCollector)
 	if metricsCollector != nil {
 		collectors[metricsCollector.applicationID] = metricsCollector

--- a/pkg/gateway/router.go
+++ b/pkg/gateway/router.go
@@ -28,7 +28,7 @@ type Router struct {
 	metricsAggregator *MetricsAggregator
 }
 
-func NewRouter(appStatRepo repository.ApplicationStat) *Router {
+func NewRouter(appStatRepo *repository.ApplicationStat) *Router {
 	router := &Router{
 		routes:    make(map[string]*httputil.ReverseProxy),
 		routeInfo: make(map[string]Route),

--- a/pkg/repository/application.go
+++ b/pkg/repository/application.go
@@ -10,24 +10,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type Application interface {
-	Insert(ctx context.Context, application model.Application) (string, error)
-	Update(ctx context.Context, application model.Application) error
-	Delete(ctx context.Context, id string) error
-	GetByID(ctx context.Context, id string) (model.Application, error)
-	GetAll(ctx context.Context) ([]model.Application, error)
-	GetByTechStack(ctx context.Context, techStackID string) ([]model.Application, error)
+type Application struct {
+	Base[model.Application]
 }
 
-type application[T any] struct {
-	Base[T]
+func NewApplication(db store.Queryable) *Application {
+	return &Application{Base[model.Application]{Store: db, Table: "applications"}}
 }
 
-func NewApplication(db store.Queryable) Application {
-	return &application[model.Application]{Base[model.Application]{Store: db, Table: "applications"}}
-}
-
-func (a *application[T]) Insert(ctx context.Context, application model.Application) (string, error) {
+func (a *Application) Insert(ctx context.Context, application model.Application) (string, error) {
 	var id string
 	query := a.BaseQueryInsert().Rows(application).Returning("id")
 	q, args, err := query.ToSQL()
@@ -44,7 +35,7 @@ func (a *application[T]) Insert(ctx context.Context, application model.Applicati
 	return id, nil
 }
 
-func (a *application[T]) Update(ctx context.Context, application model.Application) error {
+func (a *Application) Update(ctx context.Context, application model.Application) error {
 	query := filters.ApplyUpdateFilters(a.BaseQueryUpdate().Set(application), filters.IsUpdateFilter("id", application.ID))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -60,7 +51,7 @@ func (a *application[T]) Update(ctx context.Context, application model.Applicati
 	return nil
 }
 
-func (a *application[T]) Delete(ctx context.Context, id string) error {
+func (a *Application) Delete(ctx context.Context, id string) error {
 	query := filters.ApplyUpdateFilters(
 		a.BaseQueryUpdate().
 			Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")}),
@@ -81,7 +72,7 @@ func (a *application[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (a *application[T]) GetByID(ctx context.Context, id string) (model.Application, error) {
+func (a *Application) GetByID(ctx context.Context, id string) (model.Application, error) {
 	query := a.baseQuery().Where(goqu.Ex{"id": id})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -98,7 +89,7 @@ func (a *application[T]) GetByID(ctx context.Context, id string) (model.Applicat
 	return application, nil
 }
 
-func (a *application[T]) GetAll(ctx context.Context) ([]model.Application, error) {
+func (a *Application) GetAll(ctx context.Context) ([]model.Application, error) {
 	query := a.baseQuery()
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -115,7 +106,7 @@ func (a *application[T]) GetAll(ctx context.Context) ([]model.Application, error
 	return applications, nil
 }
 
-func (a *application[T]) GetByTechStack(ctx context.Context, techStackID string) ([]model.Application, error) {
+func (a *Application) GetByTechStack(ctx context.Context, techStackID string) ([]model.Application, error) {
 	query := a.baseQuery().Where(goqu.Ex{"tech_stack_id": techStackID})
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/repository/application_stat.go
+++ b/pkg/repository/application_stat.go
@@ -11,32 +11,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type ApplicationStat interface {
-	Insert(ctx context.Context, applicationStat model.ApplicationStat) error
-	Update(ctx context.Context, applicationStat model.ApplicationStat) error
-	Delete(ctx context.Context, id string) error
-	GetByID(ctx context.Context, id string) (model.ApplicationStat, error)
-	GetByApplicationID(ctx context.Context, applicationID string) ([]model.ApplicationStat, error)
-	GetByEnvironmentID(ctx context.Context, environmentID string) ([]model.ApplicationStat, error)
-	GetByApplicationIDAndEnvironmentID(ctx context.Context, applicationID, environmentID string) (model.ApplicationStat, error)
-	GetByDate(ctx context.Context, date time.Time) ([]model.ApplicationStat, error)
-	GetAll(ctx context.Context) ([]model.ApplicationStat, error)
-	GetUniqueVisitors(ctx context.Context, applicationID, environmentID string) (int, error)
-	GetDataTransfered(ctx context.Context, applicationID, environmentID string) (int, error)
-	GetRequests(ctx context.Context, applicationID, environmentID string) (int, error)
-	GetAverageResponseTime(ctx context.Context, applicationID, environmentID string) (int, error)
-	GetErrorRate(ctx context.Context, applicationID, environmentID string) (int, error)
+type ApplicationStat struct {
+	Base[model.ApplicationStat]
 }
 
-type applicationStat[T any] struct {
-	Base[T]
+func NewApplicationStat(db store.Queryable) *ApplicationStat {
+	return &ApplicationStat{Base[model.ApplicationStat]{Store: db, Table: "application_stats"}}
 }
 
-func NewApplicationStat(db store.Queryable) ApplicationStat {
-	return &applicationStat[model.ApplicationStat]{Base[model.ApplicationStat]{Store: db, Table: "application_stats"}}
-}
-
-func (a *applicationStat[T]) Insert(ctx context.Context, applicationStat model.ApplicationStat) error {
+func (a *ApplicationStat) Insert(ctx context.Context, applicationStat model.ApplicationStat) error {
 	query := a.BaseQueryInsert().Rows(applicationStat)
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -52,7 +35,7 @@ func (a *applicationStat[T]) Insert(ctx context.Context, applicationStat model.A
 	return nil
 }
 
-func (a *applicationStat[T]) Update(ctx context.Context, applicationStat model.ApplicationStat) error {
+func (a *ApplicationStat) Update(ctx context.Context, applicationStat model.ApplicationStat) error {
 	query := filters.ApplyUpdateFilters(a.BaseQueryUpdate().Set(applicationStat), filters.IsUpdateFilter("id", applicationStat.ID))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -68,7 +51,7 @@ func (a *applicationStat[T]) Update(ctx context.Context, applicationStat model.A
 	return nil
 }
 
-func (a *applicationStat[T]) Delete(ctx context.Context, id string) error {
+func (a *ApplicationStat) Delete(ctx context.Context, id string) error {
 	query := filters.ApplyUpdateFilters(
 		a.BaseQueryUpdate().
 			Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")}),
@@ -89,7 +72,7 @@ func (a *applicationStat[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (a *applicationStat[T]) GetByID(ctx context.Context, id string) (model.ApplicationStat, error) {
+func (a *ApplicationStat) GetByID(ctx context.Context, id string) (model.ApplicationStat, error) {
 	query := a.baseQuery().Where(goqu.Ex{"id": id})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -106,7 +89,7 @@ func (a *applicationStat[T]) GetByID(ctx context.Context, id string) (model.Appl
 	return applicationStat, nil
 }
 
-func (a *applicationStat[T]) GetByApplicationID(ctx context.Context, applicationID string) ([]model.ApplicationStat, error) {
+func (a *ApplicationStat) GetByApplicationID(ctx context.Context, applicationID string) ([]model.ApplicationStat, error) {
 	query := a.baseQuery().Where(goqu.Ex{"application_id": applicationID})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -123,7 +106,7 @@ func (a *applicationStat[T]) GetByApplicationID(ctx context.Context, application
 	return applicationStats, nil
 }
 
-func (a *applicationStat[T]) GetByEnvironmentID(ctx context.Context, environmentID string) ([]model.ApplicationStat, error) {
+func (a *ApplicationStat) GetByEnvironmentID(ctx context.Context, environmentID string) ([]model.ApplicationStat, error) {
 	query := a.baseQuery().Where(goqu.Ex{"environment_id": environmentID})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -140,7 +123,7 @@ func (a *applicationStat[T]) GetByEnvironmentID(ctx context.Context, environment
 	return applicationStats, nil
 }
 
-func (a *applicationStat[T]) GetByDate(ctx context.Context, date time.Time) ([]model.ApplicationStat, error) {
+func (a *ApplicationStat) GetByDate(ctx context.Context, date time.Time) ([]model.ApplicationStat, error) {
 	query := a.baseQuery().Where(goqu.Ex{"date": date})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -157,7 +140,7 @@ func (a *applicationStat[T]) GetByDate(ctx context.Context, date time.Time) ([]m
 	return applicationStats, nil
 }
 
-func (a *applicationStat[T]) GetAll(ctx context.Context) ([]model.ApplicationStat, error) {
+func (a *ApplicationStat) GetAll(ctx context.Context) ([]model.ApplicationStat, error) {
 	query := a.baseQuery()
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -174,7 +157,7 @@ func (a *applicationStat[T]) GetAll(ctx context.Context) ([]model.ApplicationSta
 	return applicationStats, nil
 }
 
-func (a *applicationStat[T]) GetUniqueVisitors(ctx context.Context, applicationID, environmentID string) (int, error) {
+func (a *ApplicationStat) GetUniqueVisitors(ctx context.Context, applicationID, environmentID string) (int, error) {
 	query := a.baseQuery().Where(goqu.Ex{"application_id": applicationID, "environment_id": environmentID}).Select(goqu.COUNT("DISTINCT(visitor_id)"))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -191,7 +174,7 @@ func (a *applicationStat[T]) GetUniqueVisitors(ctx context.Context, applicationI
 	return count, nil
 }
 
-func (a *applicationStat[T]) GetDataTransfered(ctx context.Context, applicationID, environmentID string) (int, error) {
+func (a *ApplicationStat) GetDataTransfered(ctx context.Context, applicationID, environmentID string) (int, error) {
 	query := a.baseQuery().Where(goqu.Ex{"application_id": applicationID, "environment_id": environmentID}).Select(goqu.SUM("data_transfered"))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -208,7 +191,7 @@ func (a *applicationStat[T]) GetDataTransfered(ctx context.Context, applicationI
 	return sum, nil
 }
 
-func (a *applicationStat[T]) GetRequests(ctx context.Context, applicationID, environmentID string) (int, error) {
+func (a *ApplicationStat) GetRequests(ctx context.Context, applicationID, environmentID string) (int, error) {
 	query := a.baseQuery().Where(goqu.Ex{"application_id": applicationID, "environment_id": environmentID}).Select(goqu.SUM("requests"))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -225,7 +208,7 @@ func (a *applicationStat[T]) GetRequests(ctx context.Context, applicationID, env
 	return sum, nil
 }
 
-func (a *applicationStat[T]) GetAverageResponseTime(ctx context.Context, applicationID, environmentID string) (int, error) {
+func (a *ApplicationStat) GetAverageResponseTime(ctx context.Context, applicationID, environmentID string) (int, error) {
 	query := a.baseQuery().Where(goqu.Ex{"application_id": applicationID, "environment_id": environmentID}).Select(goqu.AVG("response_time"))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -242,7 +225,7 @@ func (a *applicationStat[T]) GetAverageResponseTime(ctx context.Context, applica
 	return avg, nil
 }
 
-func (a *applicationStat[T]) GetErrorRate(ctx context.Context, applicationID, environmentID string) (int, error) {
+func (a *ApplicationStat) GetErrorRate(ctx context.Context, applicationID, environmentID string) (int, error) {
 	query := a.baseQuery().Where(goqu.Ex{"application_id": applicationID, "environment_id": environmentID}).Select(goqu.AVG("error_rate"))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -259,7 +242,7 @@ func (a *applicationStat[T]) GetErrorRate(ctx context.Context, applicationID, en
 	return avg, nil
 }
 
-func (a *applicationStat[T]) GetByApplicationIDAndEnvironmentID(ctx context.Context, applicationID, environmentID string) (model.ApplicationStat, error) {
+func (a *ApplicationStat) GetByApplicationIDAndEnvironmentID(ctx context.Context, applicationID, environmentID string) (model.ApplicationStat, error) {
 	query := a.baseQuery().Where(goqu.Ex{"application_id": applicationID, "environment_id": environmentID})
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/repository/application_user.go
+++ b/pkg/repository/application_user.go
@@ -10,24 +10,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type ApplicationUser interface {
-	Insert(ctx context.Context, applicationUser model.ApplicationUser) error
-	Update(ctx context.Context, applicationUser model.ApplicationUser) error
-	Delete(ctx context.Context, id string) error
-	GetByUserID(ctx context.Context, userID string) ([]model.ApplicationUser, error)
-	GetByApplicationID(ctx context.Context, applicationID string) ([]model.ApplicationUser, error)
-	GetAll(ctx context.Context) ([]model.ApplicationUser, error)
+type ApplicationUser struct {
+	Base[model.ApplicationUser]
 }
 
-type applicationUser[T any] struct {
-	Base[T]
+func NewApplicationUser(db store.Queryable) *ApplicationUser {
+	return &ApplicationUser{Base[model.ApplicationUser]{Store: db, Table: "application_users"}}
 }
 
-func NewApplicationUser(db store.Queryable) ApplicationUser {
-	return &applicationUser[model.ApplicationUser]{Base[model.ApplicationUser]{Store: db, Table: "application_users"}}
-}
-
-func (a *applicationUser[T]) Insert(ctx context.Context, applicationUser model.ApplicationUser) error {
+func (a *ApplicationUser) Insert(ctx context.Context, applicationUser model.ApplicationUser) error {
 	query := a.BaseQueryInsert().Rows(applicationUser)
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -43,7 +34,7 @@ func (a *applicationUser[T]) Insert(ctx context.Context, applicationUser model.A
 	return nil
 }
 
-func (a *applicationUser[T]) Update(ctx context.Context, applicationUser model.ApplicationUser) error {
+func (a *ApplicationUser) Update(ctx context.Context, applicationUser model.ApplicationUser) error {
 	query := filters.ApplyUpdateFilters(a.BaseQueryUpdate().Set(applicationUser), filters.IsUpdateFilter("application_id", applicationUser.ApplicationID), filters.IsUpdateFilter("user_id", applicationUser.UserID))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -59,7 +50,7 @@ func (a *applicationUser[T]) Update(ctx context.Context, applicationUser model.A
 	return nil
 }
 
-func (a *applicationUser[T]) Delete(ctx context.Context, id string) error {
+func (a *ApplicationUser) Delete(ctx context.Context, id string) error {
 	query := filters.ApplyUpdateFilters(
 		a.BaseQueryUpdate().
 			Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")}),
@@ -80,7 +71,7 @@ func (a *applicationUser[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (a *applicationUser[T]) GetByUserID(ctx context.Context, userID string) ([]model.ApplicationUser, error) {
+func (a *ApplicationUser) GetByUserID(ctx context.Context, userID string) ([]model.ApplicationUser, error) {
 	query := a.baseQuery().Where(goqu.Ex{"user_id": userID})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -97,7 +88,7 @@ func (a *applicationUser[T]) GetByUserID(ctx context.Context, userID string) ([]
 	return applicationUsers, nil
 }
 
-func (a *applicationUser[T]) GetByApplicationID(ctx context.Context, applicationID string) ([]model.ApplicationUser, error) {
+func (a *ApplicationUser) GetByApplicationID(ctx context.Context, applicationID string) ([]model.ApplicationUser, error) {
 	query := a.baseQuery().Where(goqu.Ex{"application_id": applicationID})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -114,7 +105,7 @@ func (a *applicationUser[T]) GetByApplicationID(ctx context.Context, application
 	return applicationUsers, nil
 }
 
-func (a *applicationUser[T]) GetAll(ctx context.Context) ([]model.ApplicationUser, error) {
+func (a *ApplicationUser) GetAll(ctx context.Context) ([]model.ApplicationUser, error) {
 	query := a.baseQuery().Where(goqu.Ex{"deleted_at": nil})
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/repository/base.go
+++ b/pkg/repository/base.go
@@ -14,21 +14,21 @@ import (
 )
 
 type Repositories struct {
-	ApplicationUser ApplicationUser
-	Application     Application
-	ApplicationStat ApplicationStat
-	Gateway         Gateway
-	GatewayConfig   GatewayConfig
-	Metadata        Metadata
-	Role            Role
-	TechStack       TechStack
-	Trace           Trace
-	User            User
-	UserOauth       UserOauth
-	UserRole        UserRole
-	UserTechStack   UserTechStack
-	VisitorInfo     VisitorInfo
-	VisitorTrace    VisitorTrace
+	ApplicationUser *ApplicationUser
+	Application     *Application
+	ApplicationStat *ApplicationStat
+	Gateway         *Gateway
+	GatewayConfig   *GatewayConfig
+	Metadata        *Metadata
+	Role            *Role
+	TechStack       *TechStack
+	Trace           *Trace
+	User            *User
+	UserOauth       *UserOAuth
+	UserRole        *UserRole
+	UserTechStack   *UserTechStack
+	VisitorInfo     *VisitorInfo
+	VisitorTrace    *VisitorTrace
 }
 
 var (

--- a/pkg/repository/gateway.go
+++ b/pkg/repository/gateway.go
@@ -10,29 +10,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type Gateway interface {
-	Insert(ctx context.Context, gateway model.Gateway) error
-	Update(ctx context.Context, gateway model.Gateway) error
-	Delete(ctx context.Context, id string) error
-	GetByID(ctx context.Context, id string) (model.Gateway, error)
-	GetAll(ctx context.Context) ([]model.Gateway, error)
-	GetByHttpMethod(ctx context.Context, httpMethod string) ([]model.Gateway, error)
-	GetByEndpoint(ctx context.Context, endpoint string) ([]model.Gateway, error)
-	GetByLogLevel(ctx context.Context, logLevel string) ([]model.Gateway, error)
-	GetByStage(ctx context.Context, stage string) ([]model.Gateway, error)
-	GetByName(ctx context.Context, name string) ([]model.Gateway, error)
-	GetByApplicationID(ctx context.Context, applicationID string) ([]model.Gateway, error)
+type Gateway struct {
+	Base[model.Gateway]
 }
 
-type gateway[T any] struct {
-	Base[T]
+func NewGateway(db store.Queryable) *Gateway {
+	return &Gateway{Base[model.Gateway]{Store: db, Table: "gateways"}}
 }
 
-func NewGateway(db store.Queryable) Gateway {
-	return &gateway[model.Gateway]{Base[model.Gateway]{Store: db, Table: "gateways"}}
-}
-
-func (g *gateway[T]) Insert(ctx context.Context, gateway model.Gateway) error {
+func (g *Gateway) Insert(ctx context.Context, gateway model.Gateway) error {
 	query := g.BaseQueryInsert().Rows(gateway)
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -48,7 +34,7 @@ func (g *gateway[T]) Insert(ctx context.Context, gateway model.Gateway) error {
 	return nil
 }
 
-func (g *gateway[T]) Update(ctx context.Context, gateway model.Gateway) error {
+func (g *Gateway) Update(ctx context.Context, gateway model.Gateway) error {
 	query := filters.ApplyUpdateFilters(g.BaseQueryUpdate().Set(gateway), filters.IsUpdateFilter("id", gateway.ID))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -64,7 +50,7 @@ func (g *gateway[T]) Update(ctx context.Context, gateway model.Gateway) error {
 	return nil
 }
 
-func (g *gateway[T]) Delete(ctx context.Context, id string) error {
+func (g *Gateway) Delete(ctx context.Context, id string) error {
 	query := filters.ApplyUpdateFilters(
 		g.BaseQueryUpdate().
 			Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")}),
@@ -85,7 +71,7 @@ func (g *gateway[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (g *gateway[T]) GetByID(ctx context.Context, id string) (model.Gateway, error) {
+func (g *Gateway) GetByID(ctx context.Context, id string) (model.Gateway, error) {
 	query := g.baseQuery().Where(goqu.Ex{"id": id})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -102,7 +88,7 @@ func (g *gateway[T]) GetByID(ctx context.Context, id string) (model.Gateway, err
 	return gateway, nil
 }
 
-func (g *gateway[T]) GetAll(ctx context.Context) ([]model.Gateway, error) {
+func (g *Gateway) GetAll(ctx context.Context) ([]model.Gateway, error) {
 	query := g.baseQuery()
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -119,7 +105,7 @@ func (g *gateway[T]) GetAll(ctx context.Context) ([]model.Gateway, error) {
 	return gateways, nil
 }
 
-func (g *gateway[T]) GetByHttpMethod(ctx context.Context, httpMethod string) ([]model.Gateway, error) {
+func (g *Gateway) GetByHttpMethod(ctx context.Context, httpMethod string) ([]model.Gateway, error) {
 	query := g.baseQuery().Where(goqu.Ex{"http_method": httpMethod})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -136,7 +122,7 @@ func (g *gateway[T]) GetByHttpMethod(ctx context.Context, httpMethod string) ([]
 	return gateways, nil
 }
 
-func (g *gateway[T]) GetByEndpoint(ctx context.Context, endpoint string) ([]model.Gateway, error) {
+func (g *Gateway) GetByEndpoint(ctx context.Context, endpoint string) ([]model.Gateway, error) {
 	query := g.baseQuery().Where(goqu.Ex{"endpoint": endpoint})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -153,7 +139,7 @@ func (g *gateway[T]) GetByEndpoint(ctx context.Context, endpoint string) ([]mode
 	return gateways, nil
 }
 
-func (g *gateway[T]) GetByLogLevel(ctx context.Context, logLevel string) ([]model.Gateway, error) {
+func (g *Gateway) GetByLogLevel(ctx context.Context, logLevel string) ([]model.Gateway, error) {
 	query := g.baseQuery().Where(goqu.Ex{"log_level": logLevel})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -170,7 +156,7 @@ func (g *gateway[T]) GetByLogLevel(ctx context.Context, logLevel string) ([]mode
 	return gateways, nil
 }
 
-func (g *gateway[T]) GetByStage(ctx context.Context, stage string) ([]model.Gateway, error) {
+func (g *Gateway) GetByStage(ctx context.Context, stage string) ([]model.Gateway, error) {
 	query := g.baseQuery().Where(goqu.Ex{"stage": stage})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -187,7 +173,7 @@ func (g *gateway[T]) GetByStage(ctx context.Context, stage string) ([]model.Gate
 	return gateways, nil
 }
 
-func (g *gateway[T]) GetByName(ctx context.Context, name string) ([]model.Gateway, error) {
+func (g *Gateway) GetByName(ctx context.Context, name string) ([]model.Gateway, error) {
 	query := g.baseQuery().Where(goqu.Ex{"name": name})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -204,7 +190,7 @@ func (g *gateway[T]) GetByName(ctx context.Context, name string) ([]model.Gatewa
 	return gateways, nil
 }
 
-func (g *gateway[T]) GetByApplicationID(ctx context.Context, applicationID string) ([]model.Gateway, error) {
+func (g *Gateway) GetByApplicationID(ctx context.Context, applicationID string) ([]model.Gateway, error) {
 	query := g.baseQuery().Where(goqu.Ex{"application_id": applicationID})
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/repository/gateway_config.go
+++ b/pkg/repository/gateway_config.go
@@ -10,20 +10,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type GatewayConfig interface {
-	Upsert(ctx context.Context, gateway model.GatewayConfig) (model.GatewayConfig, error)
-	Get(ctx context.Context) (model.GatewayConfig, error)
+type GatewayConfig struct {
+	Base[model.GatewayConfig]
 }
 
-type gatewayConfig[T any] struct {
-	Base[T]
+func NewGatewayConfig(db store.Queryable) *GatewayConfig {
+	return &GatewayConfig{Base[model.GatewayConfig]{Store: db, Table: "gateway_config"}}
 }
 
-func NewGatewayConfig(db store.Queryable) GatewayConfig {
-	return &gatewayConfig[model.GatewayConfig]{Base[model.GatewayConfig]{Store: db, Table: "gateway_config"}}
-}
-
-func (g *gatewayConfig[T]) Upsert(ctx context.Context, gateway model.GatewayConfig) (model.GatewayConfig, error) {
+func (g *GatewayConfig) Upsert(ctx context.Context, gateway model.GatewayConfig) (model.GatewayConfig, error) {
 	conf, err := g.Get(ctx)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		logger.Error("error getting actual gateway: %v", err)
@@ -61,7 +56,7 @@ func (g *gatewayConfig[T]) Upsert(ctx context.Context, gateway model.GatewayConf
 	return conf, nil
 }
 
-func (g *gatewayConfig[T]) Get(ctx context.Context) (conf model.GatewayConfig, err error) {
+func (g *GatewayConfig) Get(ctx context.Context) (conf model.GatewayConfig, err error) {
 	query := filters.ApplyFilters(g.baseQuery(), filters.LimitOffsetFilter(1, 0))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -73,6 +68,16 @@ func (g *gatewayConfig[T]) Get(ctx context.Context) (conf model.GatewayConfig, e
 		logger.Error("error running get config query: %v", err)
 		return model.GatewayConfig{}, err
 	}
+
+	return
+}
+
+func (g *GatewayConfig) createDefault(ctx context.Context) (conf model.GatewayConfig, err error) {
+	conf, err = g.InsertOne(ctx, model.GatewayConfig{
+		DefaultVersioningType: "headers",
+		DefaultVersion:        "latest",
+		LoadBalancer:          false,
+	})
 
 	return
 }

--- a/pkg/repository/metadata.go
+++ b/pkg/repository/metadata.go
@@ -9,24 +9,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type Metadata interface {
-	Create(ctx context.Context, metadata model.Metadata) error
-	Update(ctx context.Context, metadata model.Metadata) error
-	Get(ctx context.Context) (model.Metadata, error)
-	GetTeamName(ctx context.Context) (string, error)
-	GetTeamLogo(ctx context.Context) (string, error)
-	GetLanguage(ctx context.Context) (string, error)
+type Metadata struct {
+	Base[model.Metadata]
 }
 
-type metadata[T any] struct {
-	Base[T]
+func NewMetadata(db store.Queryable) *Metadata {
+	return &Metadata{Base[model.Metadata]{Store: db, Table: "metadata"}}
 }
 
-func NewMetadata(db store.Queryable) Metadata {
-	return &metadata[model.Metadata]{Base[model.Metadata]{Store: db, Table: "metadata"}}
-}
-
-func (m *metadata[T]) Create(ctx context.Context, metadata model.Metadata) error {
+func (m *Metadata) Create(ctx context.Context, metadata model.Metadata) error {
 	q := m.BaseQueryInsert().Rows(metadata)
 	query, args, err := q.ToSQL()
 	if err != nil {
@@ -42,7 +33,7 @@ func (m *metadata[T]) Create(ctx context.Context, metadata model.Metadata) error
 	return nil
 }
 
-func (m *metadata[T]) Update(ctx context.Context, metadata model.Metadata) error {
+func (m *Metadata) Update(ctx context.Context, metadata model.Metadata) error {
 	// get id from Get method
 	mtdt, err := m.Get(ctx)
 	if err != nil {
@@ -66,7 +57,7 @@ func (m *metadata[T]) Update(ctx context.Context, metadata model.Metadata) error
 	return err
 }
 
-func (m *metadata[T]) Get(ctx context.Context) (model.Metadata, error) {
+func (m *Metadata) Get(ctx context.Context) (model.Metadata, error) {
 	q := m.baseQuery().Limit(1)
 	query, args, err := q.ToSQL()
 	if err != nil {
@@ -83,7 +74,7 @@ func (m *metadata[T]) Get(ctx context.Context) (model.Metadata, error) {
 	return metadata, nil
 }
 
-func (m *metadata[T]) GetTeamName(ctx context.Context) (string, error) {
+func (m *Metadata) GetTeamName(ctx context.Context) (string, error) {
 	q := m.baseQuery().Select("team_name").Limit(1)
 	query, args, err := q.ToSQL()
 	if err != nil {
@@ -100,7 +91,7 @@ func (m *metadata[T]) GetTeamName(ctx context.Context) (string, error) {
 	return teamName, nil
 }
 
-func (m *metadata[T]) GetTeamLogo(ctx context.Context) (string, error) {
+func (m *Metadata) GetTeamLogo(ctx context.Context) (string, error) {
 	q := m.baseQuery().Select("logo_url").Limit(1)
 	query, args, err := q.ToSQL()
 	if err != nil {
@@ -117,7 +108,7 @@ func (m *metadata[T]) GetTeamLogo(ctx context.Context) (string, error) {
 	return teamLogo, nil
 }
 
-func (m *metadata[T]) GetLanguage(ctx context.Context) (string, error) {
+func (m *Metadata) GetLanguage(ctx context.Context) (string, error) {
 	q := m.baseQuery().Select("language").Limit(1)
 	query, args, err := q.ToSQL()
 	if err != nil {

--- a/pkg/repository/refresh_token.go
+++ b/pkg/repository/refresh_token.go
@@ -10,24 +10,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type RefreshToken interface {
-	Insert(ctx context.Context, refreshToken model.RefreshToken) error
-	Update(ctx context.Context, refreshToken model.RefreshToken) error
-	Delete(ctx context.Context, id string) error
-	GetByID(ctx context.Context, id string) (model.RefreshToken, error)
-	GetByUserID(ctx context.Context, userID string) (model.RefreshToken, error)
-	GetAll(ctx context.Context) ([]model.RefreshToken, error)
+type RefreshToken struct {
+	Base[model.RefreshToken]
 }
 
-type refreshToken[T any] struct {
-	Base[T]
+func NewRefreshToken(db store.Queryable) *RefreshToken {
+	return &RefreshToken{Base[model.RefreshToken]{Store: db, Table: "refresh_tokens"}}
 }
 
-func NewRefreshToken(db store.Queryable) RefreshToken {
-	return &refreshToken[model.RefreshToken]{Base[model.RefreshToken]{Store: db, Table: "refresh_tokens"}}
-}
-
-func (r *refreshToken[T]) Insert(ctx context.Context, refreshToken model.RefreshToken) error {
+func (r *RefreshToken) Insert(ctx context.Context, refreshToken model.RefreshToken) error {
 	query := r.BaseQueryInsert().Rows(refreshToken)
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -43,7 +34,7 @@ func (r *refreshToken[T]) Insert(ctx context.Context, refreshToken model.Refresh
 	return nil
 }
 
-func (r *refreshToken[T]) Update(ctx context.Context, refreshToken model.RefreshToken) error {
+func (r *RefreshToken) Update(ctx context.Context, refreshToken model.RefreshToken) error {
 	query := filters.ApplyUpdateFilters(r.BaseQueryUpdate().Set(refreshToken), filters.IsUpdateFilter("id", refreshToken.ID))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -59,7 +50,7 @@ func (r *refreshToken[T]) Update(ctx context.Context, refreshToken model.Refresh
 	return nil
 }
 
-func (r *refreshToken[T]) Delete(ctx context.Context, id string) error {
+func (r *RefreshToken) Delete(ctx context.Context, id string) error {
 	query := filters.ApplyUpdateFilters(
 		r.BaseQueryUpdate().
 			Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")}),
@@ -80,7 +71,7 @@ func (r *refreshToken[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (r *refreshToken[T]) GetByID(ctx context.Context, id string) (model.RefreshToken, error) {
+func (r *RefreshToken) GetByID(ctx context.Context, id string) (model.RefreshToken, error) {
 	query := r.baseQuery().Where(goqu.Ex{"id": id})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -97,7 +88,7 @@ func (r *refreshToken[T]) GetByID(ctx context.Context, id string) (model.Refresh
 	return refreshToken, nil
 }
 
-func (r *refreshToken[T]) GetByUserID(ctx context.Context, userID string) (model.RefreshToken, error) {
+func (r *RefreshToken) GetByUserID(ctx context.Context, userID string) (model.RefreshToken, error) {
 	query := r.baseQuery().Where(goqu.Ex{"user_id": userID})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -114,7 +105,7 @@ func (r *refreshToken[T]) GetByUserID(ctx context.Context, userID string) (model
 	return refreshToken, nil
 }
 
-func (r *refreshToken[T]) GetAll(ctx context.Context) ([]model.RefreshToken, error) {
+func (r *RefreshToken) GetAll(ctx context.Context) ([]model.RefreshToken, error) {
 	query := r.baseQuery()
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/repository/role.go
+++ b/pkg/repository/role.go
@@ -9,24 +9,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type Role interface {
-	Insert(context.Context, model.Role) error
-	GetByID(context.Context, string) (model.Role, error)
-	GetByName(context.Context, string) (model.Role, error)
-	Get(context.Context) ([]model.Role, error)
-	Update(context.Context, string, model.Role) error
-	Delete(context.Context, string) error
+type Role struct {
+	Base[model.Role]
 }
 
-type role[T any] struct {
-	Base[T]
+func NewRole(db store.Queryable) *Role {
+	return &Role{Base[model.Role]{Store: db, Table: "roles"}}
 }
 
-func NewRole(db store.Queryable) Role {
-	return &role[model.Role]{Base[model.Role]{Store: db, Table: "roles"}}
-}
-
-func (r *role[T]) Insert(ctx context.Context, role model.Role) error {
+func (r *Role) Insert(ctx context.Context, role model.Role) error {
 	q := r.BaseQueryInsert().Rows(role)
 	query, args, err := q.ToSQL()
 	if err != nil {
@@ -40,7 +31,7 @@ func (r *role[T]) Insert(ctx context.Context, role model.Role) error {
 	return nil
 }
 
-func (r *role[T]) GetByID(ctx context.Context, id string) (model.Role, error) {
+func (r *Role) GetByID(ctx context.Context, id string) (model.Role, error) {
 	var role model.Role
 	q := filters.ApplyFilters(r.baseQuery(), filters.IsSelectFilter("id", id))
 	query, args, err := q.ToSQL()
@@ -55,7 +46,7 @@ func (r *role[T]) GetByID(ctx context.Context, id string) (model.Role, error) {
 	return role, nil
 }
 
-func (r *role[T]) GetByName(ctx context.Context, name string) (model.Role, error) {
+func (r *Role) GetByName(ctx context.Context, name string) (model.Role, error) {
 	var role model.Role
 	q := filters.ApplyFilters(r.baseQuery(), filters.IsSelectFilter("name", name))
 	query, args, err := q.ToSQL()
@@ -70,7 +61,7 @@ func (r *role[T]) GetByName(ctx context.Context, name string) (model.Role, error
 	return role, nil
 }
 
-func (r *role[T]) Get(ctx context.Context) ([]model.Role, error) {
+func (r *Role) Get(ctx context.Context) ([]model.Role, error) {
 	var roles []model.Role
 	q := r.baseQuery()
 	query, args, err := q.ToSQL()
@@ -85,7 +76,7 @@ func (r *role[T]) Get(ctx context.Context) ([]model.Role, error) {
 	return roles, nil
 }
 
-func (r *role[T]) Update(ctx context.Context, id string, role model.Role) error {
+func (r *Role) Update(ctx context.Context, id string, role model.Role) error {
 	q := r.BaseQueryUpdate().Set(role).Where(goqu.Ex{"id": id})
 	query, args, err := q.ToSQL()
 	if err != nil {
@@ -99,7 +90,7 @@ func (r *role[T]) Update(ctx context.Context, id string, role model.Role) error 
 	return nil
 }
 
-func (r *role[T]) Delete(ctx context.Context, id string) error {
+func (r *Role) Delete(ctx context.Context, id string) error {
 	q := r.BaseQueryUpdate().Where(goqu.Ex{"id": id}).Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")})
 	query, args, err := q.ToSQL()
 	if err != nil {

--- a/pkg/repository/tech_stack.go
+++ b/pkg/repository/tech_stack.go
@@ -12,24 +12,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type TechStack interface {
-	FindOrCreate(ctx context.Context, name string) (model.TechStack, error)
-	Insert(ctx context.Context, techStack model.TechStack) error
-	Update(ctx context.Context, id string, techStack model.TechStack) error
-	Delete(ctx context.Context, id string) error
-	GetByID(ctx context.Context, id string) (model.TechStack, error)
-	GetAll(ctx context.Context) ([]model.TechStack, error)
+type TechStack struct {
+	Base[model.TechStack]
 }
 
-type techStack[T any] struct {
-	Base[T]
+func NewTechStack(db store.Queryable) *TechStack {
+	return &TechStack{Base[model.TechStack]{Store: db, Table: "tech_stacks"}}
 }
 
-func NewTechStack(db store.Queryable) TechStack {
-	return &techStack[model.TechStack]{Base[model.TechStack]{Store: db, Table: "tech_stacks"}}
-}
-
-func (t *techStack[T]) FindOrCreate(ctx context.Context, name string) (model.TechStack, error) {
+func (t *TechStack) FindOrCreate(ctx context.Context, name string) (model.TechStack, error) {
 	query := t.baseQuery().Where(goqu.Ex{"name": name})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -62,7 +53,7 @@ func (t *techStack[T]) FindOrCreate(ctx context.Context, name string) (model.Tec
 	return techStack, nil
 }
 
-func (t *techStack[T]) Insert(ctx context.Context, techStack model.TechStack) error {
+func (t *TechStack) Insert(ctx context.Context, techStack model.TechStack) error {
 	query := t.BaseQueryInsert().Rows(techStack)
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -78,7 +69,7 @@ func (t *techStack[T]) Insert(ctx context.Context, techStack model.TechStack) er
 	return nil
 }
 
-func (t *techStack[T]) Update(ctx context.Context, id string, techStack model.TechStack) error {
+func (t *TechStack) Update(ctx context.Context, id string, techStack model.TechStack) error {
 	query := filters.ApplyUpdateFilters(t.BaseQueryUpdate().Set(techStack), filters.IsUpdateFilter("id", id))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -94,7 +85,7 @@ func (t *techStack[T]) Update(ctx context.Context, id string, techStack model.Te
 	return nil
 }
 
-func (t *techStack[T]) Delete(ctx context.Context, id string) error {
+func (t *TechStack) Delete(ctx context.Context, id string) error {
 	query := filters.ApplyUpdateFilters(
 		t.BaseQueryUpdate().
 			Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")}),
@@ -115,7 +106,7 @@ func (t *techStack[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (t *techStack[T]) GetByID(ctx context.Context, id string) (model.TechStack, error) {
+func (t *TechStack) GetByID(ctx context.Context, id string) (model.TechStack, error) {
 	query := t.baseQuery().Where(goqu.Ex{"id": id})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -132,7 +123,7 @@ func (t *techStack[T]) GetByID(ctx context.Context, id string) (model.TechStack,
 	return techStack, nil
 }
 
-func (t *techStack[T]) GetAll(ctx context.Context) ([]model.TechStack, error) {
+func (t *TechStack) GetAll(ctx context.Context) ([]model.TechStack, error) {
 	query := t.baseQuery().Where(goqu.Ex{"deleted_at": nil})
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/repository/trace.go
+++ b/pkg/repository/trace.go
@@ -10,27 +10,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type Trace interface {
-	Insert(ctx context.Context, trace model.Trace) error
-	Update(ctx context.Context, trace model.Trace) error
-	Delete(ctx context.Context, id string) error
-	GetByID(ctx context.Context, id string) (model.Trace, error)
-	GetAll(ctx context.Context) ([]model.Trace, error)
-	GetByUserID(ctx context.Context, userID string) ([]model.Trace, error)
-	GetByType(ctx context.Context, traceType string) ([]model.Trace, error)
-	GetByAction(ctx context.Context, action string) ([]model.Trace, error)
-	GetByActionTimestamp(ctx context.Context, timestamp model.Date) ([]model.Trace, error)
+type Trace struct {
+	Base[model.Trace]
 }
 
-type trace[T any] struct {
-	Base[T]
+func NewTrace(db store.Queryable) *Trace {
+	return &Trace{Base[model.Trace]{Store: db, Table: "traces"}}
 }
 
-func NewTrace(db store.Queryable) Trace {
-	return &trace[model.Trace]{Base[model.Trace]{Store: db, Table: "traces"}}
-}
-
-func (t *trace[T]) Insert(ctx context.Context, trace model.Trace) error {
+func (t *Trace) Insert(ctx context.Context, trace model.Trace) error {
 	query := t.BaseQueryInsert().Rows(trace)
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -46,7 +34,7 @@ func (t *trace[T]) Insert(ctx context.Context, trace model.Trace) error {
 	return nil
 }
 
-func (t *trace[T]) Update(ctx context.Context, trace model.Trace) error {
+func (t *Trace) Update(ctx context.Context, trace model.Trace) error {
 	query := filters.ApplyUpdateFilters(t.BaseQueryUpdate().Set(trace), filters.IsUpdateFilter("id", trace.ID))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -62,7 +50,7 @@ func (t *trace[T]) Update(ctx context.Context, trace model.Trace) error {
 	return nil
 }
 
-func (t *trace[T]) Delete(ctx context.Context, id string) error {
+func (t *Trace) Delete(ctx context.Context, id string) error {
 	query := filters.ApplyUpdateFilters(
 		t.BaseQueryUpdate().
 			Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")}),
@@ -83,7 +71,7 @@ func (t *trace[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (t *trace[T]) GetByID(ctx context.Context, id string) (model.Trace, error) {
+func (t *Trace) GetByID(ctx context.Context, id string) (model.Trace, error) {
 	query := t.baseQuery().Where(goqu.Ex{"id": id})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -100,7 +88,7 @@ func (t *trace[T]) GetByID(ctx context.Context, id string) (model.Trace, error) 
 	return trace, nil
 }
 
-func (t *trace[T]) GetAll(ctx context.Context) ([]model.Trace, error) {
+func (t *Trace) GetAll(ctx context.Context) ([]model.Trace, error) {
 	query := t.baseQuery()
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -117,7 +105,7 @@ func (t *trace[T]) GetAll(ctx context.Context) ([]model.Trace, error) {
 	return traces, nil
 }
 
-func (t *trace[T]) GetByUserID(ctx context.Context, userID string) ([]model.Trace, error) {
+func (t *Trace) GetByUserID(ctx context.Context, userID string) ([]model.Trace, error) {
 	query := t.baseQuery().Where(goqu.Ex{"user_id": userID})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -134,7 +122,7 @@ func (t *trace[T]) GetByUserID(ctx context.Context, userID string) ([]model.Trac
 	return traces, nil
 }
 
-func (t *trace[T]) GetByType(ctx context.Context, traceType string) ([]model.Trace, error) {
+func (t *Trace) GetByType(ctx context.Context, traceType string) ([]model.Trace, error) {
 	query := t.baseQuery().Where(goqu.Ex{"type": traceType})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -151,7 +139,7 @@ func (t *trace[T]) GetByType(ctx context.Context, traceType string) ([]model.Tra
 	return traces, nil
 }
 
-func (t *trace[T]) GetByAction(ctx context.Context, action string) ([]model.Trace, error) {
+func (t *Trace) GetByAction(ctx context.Context, action string) ([]model.Trace, error) {
 	query := t.baseQuery().Where(goqu.Ex{"action": action})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -168,7 +156,7 @@ func (t *trace[T]) GetByAction(ctx context.Context, action string) ([]model.Trac
 	return traces, nil
 }
 
-func (t *trace[T]) GetByActionTimestamp(ctx context.Context, timestamp model.Date) ([]model.Trace, error) {
+func (t *Trace) GetByActionTimestamp(ctx context.Context, timestamp model.Date) ([]model.Trace, error) {
 	query := t.baseQuery().Where(goqu.Ex{"timestamp": timestamp})
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/repository/user.go
+++ b/pkg/repository/user.go
@@ -9,27 +9,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type User interface {
-	Create(ctx context.Context, user model.User) (model.User, error)
-	Get(ctx context.Context, id string) (model.User, error)
-	Update(ctx context.Context, user model.User) error
-	Delete(ctx context.Context, id string) error
-	List(ctx context.Context, limit, offset uint) ([]model.User, error)
-	GetByEmail(ctx context.Context, email string) (model.User, error)
-	CreateInvitation(ctx context.Context, invitation model.Invitation) error
-	GetInvitationByToken(ctx context.Context, token string) (model.Invitation, error)
-	UpdateInvitation(ctx context.Context, invitation model.Invitation) error
+type User struct {
+	Base[model.User]
 }
 
-type user[T any] struct {
-	Base[T]
+func NewUser(db store.Queryable) *User {
+	return &User{Base: Base[model.User]{Store: db, Table: "users"}}
 }
 
-func NewUser(db store.Queryable) User {
-	return &user[model.User]{Base: Base[model.User]{Store: db, Table: "users"}}
-}
-
-func (u *user[T]) Create(ctx context.Context, user model.User) (model.User, error) {
+func (u *User) Create(ctx context.Context, user model.User) (model.User, error) {
 	query := u.BaseQueryInsert().
 		Rows(user).
 		Returning("*")
@@ -47,7 +35,7 @@ func (u *user[T]) Create(ctx context.Context, user model.User) (model.User, erro
 	return newUser, nil
 }
 
-func (u *user[T]) Get(ctx context.Context, id string) (model.User, error) {
+func (u *User) Get(ctx context.Context, id string) (model.User, error) {
 	query := filters.ApplyFilters(u.baseQuery(), filters.IsSelectFilter("id", id))
 
 	q, args, err := query.ToSQL()
@@ -63,7 +51,7 @@ func (u *user[T]) Get(ctx context.Context, id string) (model.User, error) {
 	return user, nil
 }
 
-func (u *user[T]) Update(ctx context.Context, user model.User) error {
+func (u *User) Update(ctx context.Context, user model.User) error {
 	query := u.BaseQueryUpdate().
 		Set(user).
 		Where(goqu.Ex{"id": user.ID})
@@ -80,7 +68,7 @@ func (u *user[T]) Update(ctx context.Context, user model.User) error {
 	return nil
 }
 
-func (u *user[T]) Delete(ctx context.Context, id string) error {
+func (u *User) Delete(ctx context.Context, id string) error {
 	query := u.BaseQueryUpdate().
 		Set(goqu.Record{"deleted_at": "CURRENT_TIMESTAMP"}).
 		Where(goqu.Ex{"id": id})
@@ -97,7 +85,7 @@ func (u *user[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (u *user[T]) List(ctx context.Context, limit, offset uint) ([]model.User, error) {
+func (u *User) List(ctx context.Context, limit, offset uint) ([]model.User, error) {
 	query := u.baseQuery().
 		Limit(limit).
 		Offset(offset)
@@ -115,7 +103,7 @@ func (u *user[T]) List(ctx context.Context, limit, offset uint) ([]model.User, e
 	return users, nil
 }
 
-func (u *user[T]) GetByEmail(ctx context.Context, email string) (model.User, error) {
+func (u *User) GetByEmail(ctx context.Context, email string) (model.User, error) {
 	query := filters.ApplyFilters(u.baseQuery(), filters.IsSelectFilter("email", email))
 
 	q, args, err := query.ToSQL()
@@ -131,7 +119,7 @@ func (u *user[T]) GetByEmail(ctx context.Context, email string) (model.User, err
 	return user, nil
 }
 
-func (u *user[T]) CreateInvitation(ctx context.Context, invitation model.Invitation) error {
+func (u *User) CreateInvitation(ctx context.Context, invitation model.Invitation) error {
 	query := goqu.Insert("invitations").Rows(invitation)
 
 	q, args, err := query.ToSQL()
@@ -145,7 +133,7 @@ func (u *user[T]) CreateInvitation(ctx context.Context, invitation model.Invitat
 	return err
 }
 
-func (u *user[T]) GetInvitationByToken(ctx context.Context, token string) (model.Invitation, error) {
+func (u *User) GetInvitationByToken(ctx context.Context, token string) (model.Invitation, error) {
 	query := goqu.From("invitations").Where(goqu.Ex{"token": token})
 
 	q, args, err := query.ToSQL()
@@ -161,7 +149,7 @@ func (u *user[T]) GetInvitationByToken(ctx context.Context, token string) (model
 	return invitation, nil
 }
 
-func (u *user[T]) UpdateInvitation(ctx context.Context, invitation model.Invitation) error {
+func (u *User) UpdateInvitation(ctx context.Context, invitation model.Invitation) error {
 	query := goqu.Update("invitations").
 		Set(invitation).
 		Where(goqu.Ex{"id": invitation.ID})

--- a/pkg/repository/user_oauth.go
+++ b/pkg/repository/user_oauth.go
@@ -9,21 +9,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type UserOauth interface {
-	Insert(ctx context.Context, user model.UserOAuth) error
-	GetByOAuthID(ctx context.Context, oauthID string) (model.UserOAuth, error)
-	GetByUserID(ctx context.Context, userID string) (model.UserOAuth, error)
+type UserOAuth struct {
+	Base[model.UserOAuth]
 }
 
-type userOauth[T any] struct {
-	Base[T]
+func NewUserOauth(db store.Queryable) *UserOAuth {
+	return &UserOAuth{Base[model.UserOAuth]{Store: db, Table: "user_oauth"}}
 }
 
-func NewUserOauth(db store.Queryable) UserOauth {
-	return &userOauth[model.UserOAuth]{Base[model.UserOAuth]{Store: db, Table: "user_oauth"}}
-}
-
-func (u *userOauth[T]) Insert(ctx context.Context, user model.UserOAuth) error {
+func (u *UserOAuth) Insert(ctx context.Context, user model.UserOAuth) error {
 	query := u.BaseQueryInsert().Rows(user)
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -40,7 +34,7 @@ func (u *userOauth[T]) Insert(ctx context.Context, user model.UserOAuth) error {
 	return nil
 }
 
-func (u *userOauth[T]) GetByOAuthID(ctx context.Context, oauthID string) (model.UserOAuth, error) {
+func (u *UserOAuth) GetByOAuthID(ctx context.Context, oauthID string) (model.UserOAuth, error) {
 	query := filters.ApplyFilters(u.baseQuery(), filters.IsSelectFilter("oauth_id", oauthID))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -58,7 +52,7 @@ func (u *userOauth[T]) GetByOAuthID(ctx context.Context, oauthID string) (model.
 	return user, nil
 }
 
-func (u *userOauth[T]) GetByUserID(ctx context.Context, userID string) (model.UserOAuth, error) {
+func (u *UserOAuth) GetByUserID(ctx context.Context, userID string) (model.UserOAuth, error) {
 	query := filters.ApplyFilters(u.baseQuery(), filters.IsSelectFilter("user_id", userID))
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/repository/user_role.go
+++ b/pkg/repository/user_role.go
@@ -9,21 +9,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type UserRole interface {
-	GetByUserID(context.Context, string) ([]model.UserRoles, error)
-	GetByRoleID(context.Context, string) ([]model.UserRoles, error)
-	Insert(context.Context, model.UserRoles) (model.UserRoles, error)
+type UserRole struct {
+	Base[model.UserRoles]
 }
 
-type userRole[T any] struct {
-	Base[T]
+func NewUserRole(db store.Queryable) *UserRole {
+	return &UserRole{Base[model.UserRoles]{Store: db, Table: "user_roles"}}
 }
 
-func NewUserRole(db store.Queryable) UserRole {
-	return &userRole[model.UserRoles]{Base[model.UserRoles]{Store: db, Table: "user_roles"}}
-}
-
-func (u *userRole[T]) GetByUserID(ctx context.Context, userID string) ([]model.UserRoles, error) {
+func (u *UserRole) GetByUserID(ctx context.Context, userID string) ([]model.UserRoles, error) {
 	q := u.baseQuery("ur").
 		Select(
 			goqu.I("ur.*"),
@@ -60,7 +54,7 @@ func (u *userRole[T]) GetByUserID(ctx context.Context, userID string) ([]model.U
 	return userRoles, nil
 }
 
-func (u *userRole[T]) GetByRoleID(ctx context.Context, roleID string) ([]model.UserRoles, error) {
+func (u *UserRole) GetByRoleID(ctx context.Context, roleID string) ([]model.UserRoles, error) {
 	q := u.baseQuery("ur").
 		Select(
 			goqu.I("ur.*"),
@@ -91,7 +85,7 @@ func (u *userRole[T]) GetByRoleID(ctx context.Context, roleID string) ([]model.U
 	return userRoles, nil
 }
 
-func (u *userRole[T]) Insert(ctx context.Context, userRole model.UserRoles) (model.UserRoles, error) {
+func (u *UserRole) Insert(ctx context.Context, userRole model.UserRoles) (model.UserRoles, error) {
 	q := u.BaseQueryInsert().
 		Rows(userRole).
 		Returning("*")

--- a/pkg/repository/user_tech_stack.go
+++ b/pkg/repository/user_tech_stack.go
@@ -10,25 +10,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type UserTechStack interface {
-	Insert(ctx context.Context, userTechStack model.UserTechStack) error
-	Update(ctx context.Context, userTechStack model.UserTechStack) error
-	Delete(ctx context.Context, id string) error
-	GetByUserID(ctx context.Context, userID string) ([]model.UserTechStack, error)
-	GetByTechStackID(ctx context.Context, techStackID string) ([]model.UserTechStack, error)
-	GetByUserIDAndTechStackID(ctx context.Context, userID, techStackID string) (model.UserTechStack, error)
-	GetAll(ctx context.Context) ([]model.UserTechStack, error)
+type UserTechStack struct {
+	Base[model.UserTechStack]
 }
 
-type userTechStack[T any] struct {
-	Base[T]
+func NewUserTechStack(db store.Queryable) *UserTechStack {
+	return &UserTechStack{Base[model.UserTechStack]{Store: db, Table: "user_tech_stacks"}}
 }
 
-func NewUserTechStack(db store.Queryable) UserTechStack {
-	return &userTechStack[model.UserTechStack]{Base[model.UserTechStack]{Store: db, Table: "user_tech_stacks"}}
-}
-
-func (u *userTechStack[T]) Insert(ctx context.Context, userTechStack model.UserTechStack) error {
+func (u *UserTechStack) Insert(ctx context.Context, userTechStack model.UserTechStack) error {
 	query := u.BaseQueryInsert().Rows(userTechStack)
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -44,7 +34,7 @@ func (u *userTechStack[T]) Insert(ctx context.Context, userTechStack model.UserT
 	return nil
 }
 
-func (u *userTechStack[T]) Update(ctx context.Context, userTechStack model.UserTechStack) error {
+func (u *UserTechStack) Update(ctx context.Context, userTechStack model.UserTechStack) error {
 	query := filters.ApplyUpdateFilters(
 		u.BaseQueryUpdate().Set(userTechStack),
 		filters.IsUpdateFilter("user_id", userTechStack.UserID),
@@ -64,7 +54,7 @@ func (u *userTechStack[T]) Update(ctx context.Context, userTechStack model.UserT
 	return nil
 }
 
-func (u *userTechStack[T]) Delete(ctx context.Context, id string) error {
+func (u *UserTechStack) Delete(ctx context.Context, id string) error {
 	query := filters.ApplyUpdateFilters(
 		u.BaseQueryUpdate().
 			Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")}),
@@ -85,7 +75,7 @@ func (u *userTechStack[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (u *userTechStack[T]) GetByUserID(ctx context.Context, userID string) ([]model.UserTechStack, error) {
+func (u *UserTechStack) GetByUserID(ctx context.Context, userID string) ([]model.UserTechStack, error) {
 	query := u.baseQuery("ut").
 		Select(
 			goqu.I("ut.*"),
@@ -121,7 +111,7 @@ func (u *userTechStack[T]) GetByUserID(ctx context.Context, userID string) ([]mo
 	return userTechStacks, nil
 }
 
-func (u *userTechStack[T]) GetByTechStackID(ctx context.Context, techStackID string) ([]model.UserTechStack, error) {
+func (u *UserTechStack) GetByTechStackID(ctx context.Context, techStackID string) ([]model.UserTechStack, error) {
 	query := u.baseQuery("ut").
 		Select(
 			goqu.I("ut.*"),
@@ -157,7 +147,7 @@ func (u *userTechStack[T]) GetByTechStackID(ctx context.Context, techStackID str
 	return userTechStacks, nil
 }
 
-func (u *userTechStack[T]) GetByUserIDAndTechStackID(ctx context.Context, userID, techStackID string) (model.UserTechStack, error) {
+func (u *UserTechStack) GetByUserIDAndTechStackID(ctx context.Context, userID, techStackID string) (model.UserTechStack, error) {
 	query := u.baseQuery().Where(goqu.Ex{"user_id": userID, "tech_stack_id": techStackID})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -174,7 +164,7 @@ func (u *userTechStack[T]) GetByUserIDAndTechStackID(ctx context.Context, userID
 	return userTechStack, nil
 }
 
-func (u *userTechStack[T]) GetAll(ctx context.Context) ([]model.UserTechStack, error) {
+func (u *UserTechStack) GetAll(ctx context.Context) ([]model.UserTechStack, error) {
 	query := u.baseQuery()
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/repository/visitor_info.go
+++ b/pkg/repository/visitor_info.go
@@ -10,23 +10,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type VisitorInfo interface {
-	Insert(ctx context.Context, visitorInfo model.VisitorInfo) error
-	Update(ctx context.Context, visitorInfo model.VisitorInfo) error
-	Delete(ctx context.Context, id string) error
-	GetByID(ctx context.Context, id string) (model.VisitorInfo, error)
-	GetAll(ctx context.Context) ([]model.VisitorInfo, error)
+type VisitorInfo struct {
+	Base[model.VisitorInfo]
 }
 
-type visitorInfo[T any] struct {
-	Base[T]
+func NewVisitor(db store.Queryable) *VisitorInfo {
+	return &VisitorInfo{Base[model.VisitorInfo]{Store: db, Table: "visitor_info"}}
 }
 
-func NewVisitor(db store.Queryable) VisitorInfo {
-	return &visitorInfo[model.VisitorInfo]{Base[model.VisitorInfo]{Store: db, Table: "visitor_info"}}
-}
-
-func (v *visitorInfo[T]) GetByID(ctx context.Context, id string) (model.VisitorInfo, error) {
+func (v *VisitorInfo) GetByID(ctx context.Context, id string) (model.VisitorInfo, error) {
 	query := v.baseQuery().Where(goqu.Ex{"id": id})
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -43,7 +35,7 @@ func (v *visitorInfo[T]) GetByID(ctx context.Context, id string) (model.VisitorI
 	return visitorInfo, nil
 }
 
-func (v *visitorInfo[T]) Insert(ctx context.Context, visitorInfo model.VisitorInfo) error {
+func (v *VisitorInfo) Insert(ctx context.Context, visitorInfo model.VisitorInfo) error {
 	query := v.BaseQueryInsert().Rows(visitorInfo)
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -59,7 +51,7 @@ func (v *visitorInfo[T]) Insert(ctx context.Context, visitorInfo model.VisitorIn
 	return nil
 }
 
-func (v *visitorInfo[T]) Update(ctx context.Context, visitorInfo model.VisitorInfo) error {
+func (v *VisitorInfo) Update(ctx context.Context, visitorInfo model.VisitorInfo) error {
 	query := filters.ApplyUpdateFilters(v.BaseQueryUpdate().Set(visitorInfo), filters.IsUpdateFilter("id", visitorInfo.ID))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -75,7 +67,7 @@ func (v *visitorInfo[T]) Update(ctx context.Context, visitorInfo model.VisitorIn
 	return nil
 }
 
-func (v *visitorInfo[T]) Delete(ctx context.Context, id string) error {
+func (v *VisitorInfo) Delete(ctx context.Context, id string) error {
 	query := filters.ApplyUpdateFilters(
 		v.BaseQueryUpdate().
 			Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")}),
@@ -96,7 +88,7 @@ func (v *visitorInfo[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (v *visitorInfo[T]) GetAll(ctx context.Context) ([]model.VisitorInfo, error) {
+func (v *VisitorInfo) GetAll(ctx context.Context) ([]model.VisitorInfo, error) {
 	query := v.baseQuery()
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/repository/visitor_trace.go
+++ b/pkg/repository/visitor_trace.go
@@ -10,24 +10,15 @@ import (
 	"neploy.dev/pkg/store"
 )
 
-type VisitorTrace interface {
-	Insert(ctx context.Context, visitorTraces model.VisitorTrace) error
-	Update(ctx context.Context, visitorTraces model.VisitorTrace) error
-	Delete(ctx context.Context, id string) error
-	GetByID(ctx context.Context, id string) (model.VisitorTrace, error)
-	GetAll(ctx context.Context) ([]model.VisitorTrace, error)
-	GetByVisitorID(ctx context.Context, visitorID string) ([]model.VisitorTrace, error)
+type VisitorTrace struct {
+	Base[model.VisitorTrace]
 }
 
-type visitorTraces[T any] struct {
-	Base[T]
+func NewVisitorTrace(db store.Queryable) *VisitorTrace {
+	return &VisitorTrace{Base[model.VisitorTrace]{Store: db, Table: "visitor_traces"}}
 }
 
-func NewVisitorTrace(db store.Queryable) VisitorTrace {
-	return &visitorTraces[model.VisitorTrace]{Base[model.VisitorTrace]{Store: db, Table: "visitor_traces"}}
-}
-
-func (v *visitorTraces[T]) Insert(ctx context.Context, visitorTraces model.VisitorTrace) error {
+func (v *VisitorTrace) Insert(ctx context.Context, visitorTraces model.VisitorTrace) error {
 	query := v.BaseQueryInsert().Rows(visitorTraces)
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -43,7 +34,7 @@ func (v *visitorTraces[T]) Insert(ctx context.Context, visitorTraces model.Visit
 	return nil
 }
 
-func (v *visitorTraces[T]) Update(ctx context.Context, visitorTraces model.VisitorTrace) error {
+func (v *VisitorTrace) Update(ctx context.Context, visitorTraces model.VisitorTrace) error {
 	query := filters.ApplyUpdateFilters(v.BaseQueryUpdate().Set(visitorTraces), filters.IsUpdateFilter("id", visitorTraces.ID))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -59,7 +50,7 @@ func (v *visitorTraces[T]) Update(ctx context.Context, visitorTraces model.Visit
 	return nil
 }
 
-func (v *visitorTraces[T]) Delete(ctx context.Context, id string) error {
+func (v *VisitorTrace) Delete(ctx context.Context, id string) error {
 	query := filters.ApplyUpdateFilters(
 		v.BaseQueryUpdate().
 			Set(goqu.Record{"deleted_at": goqu.L("CURRENT_TIMESTAMP")}),
@@ -80,7 +71,7 @@ func (v *visitorTraces[T]) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (v *visitorTraces[T]) GetByID(ctx context.Context, id string) (model.VisitorTrace, error) {
+func (v *VisitorTrace) GetByID(ctx context.Context, id string) (model.VisitorTrace, error) {
 	query := v.baseQuery().Where(goqu.C("id").Eq(id))
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -97,7 +88,7 @@ func (v *visitorTraces[T]) GetByID(ctx context.Context, id string) (model.Visito
 	return visitorTraces, nil
 }
 
-func (v *visitorTraces[T]) GetAll(ctx context.Context) ([]model.VisitorTrace, error) {
+func (v *VisitorTrace) GetAll(ctx context.Context) ([]model.VisitorTrace, error) {
 	query := v.baseQuery()
 	q, args, err := query.ToSQL()
 	if err != nil {
@@ -114,7 +105,7 @@ func (v *visitorTraces[T]) GetAll(ctx context.Context) ([]model.VisitorTrace, er
 	return visitorTraces, nil
 }
 
-func (v *visitorTraces[T]) GetByVisitorID(ctx context.Context, visitorID string) ([]model.VisitorTrace, error) {
+func (v *VisitorTrace) GetByVisitorID(ctx context.Context, visitorID string) ([]model.VisitorTrace, error) {
 	query := v.baseQuery().Where(goqu.C("visitor_id").Eq(visitorID))
 	q, args, err := query.ToSQL()
 	if err != nil {

--- a/pkg/service/gateway.go
+++ b/pkg/service/gateway.go
@@ -27,12 +27,12 @@ type Gateway interface {
 
 type gateway struct {
 	router   *neployway.Router
-	repo     repository.Gateway
-	appRepo  repository.Application
-	confRepo repository.GatewayConfig
+	repo     *repository.Gateway
+	appRepo  *repository.Application
+	confRepo *repository.GatewayConfig
 }
 
-func NewGateway(repo repository.Gateway, appRepo repository.Application, statRepo repository.ApplicationStat, confRepo repository.GatewayConfig) Gateway {
+func NewGateway(repo *repository.Gateway, appRepo *repository.Application, statRepo *repository.ApplicationStat, confRepo *repository.GatewayConfig) Gateway {
 	return &gateway{
 		router:   neployway.NewRouter(statRepo),
 		repo:     repo,

--- a/pkg/service/health_checker.go
+++ b/pkg/service/health_checker.go
@@ -18,14 +18,14 @@ type HealthChecker interface {
 }
 
 type healthChecker struct {
-	gatewayRepo repository.Gateway
-	appRepo     repository.Application
+	gatewayRepo *repository.Gateway
+	appRepo     *repository.Application
 	interval    time.Duration
 	stopChan    chan struct{}
 	wg          sync.WaitGroup
 }
 
-func NewHealthChecker(gatewayRepo repository.Gateway, appRepo repository.Application, interval time.Duration) HealthChecker {
+func NewHealthChecker(gatewayRepo *repository.Gateway, appRepo *repository.Application, interval time.Duration) HealthChecker {
 	return &healthChecker{
 		gatewayRepo: gatewayRepo,
 		appRepo:     appRepo,

--- a/pkg/service/metadata.go
+++ b/pkg/service/metadata.go
@@ -16,10 +16,10 @@ type Metadata interface {
 }
 
 type metadata struct {
-	repo repository.Metadata
+	repo *repository.Metadata
 }
 
-func NewMetadata(repo repository.Metadata) Metadata {
+func NewMetadata(repo *repository.Metadata) Metadata {
 	return &metadata{repo}
 }
 

--- a/pkg/service/role.go
+++ b/pkg/service/role.go
@@ -19,11 +19,11 @@ type Role interface {
 }
 
 type role struct {
-	roleRepo     repository.Role
-	userRoleRepo repository.UserRole
+	roleRepo     *repository.Role
+	userRoleRepo *repository.UserRole
 }
 
-func NewRole(roleRepo repository.Role, userRoleRepo repository.UserRole) Role {
+func NewRole(roleRepo *repository.Role, userRoleRepo *repository.UserRole) Role {
 	return &role{roleRepo, userRoleRepo}
 }
 

--- a/pkg/service/tech_stack.go
+++ b/pkg/service/tech_stack.go
@@ -17,11 +17,11 @@ type TechStack interface {
 }
 
 type techStack struct {
-	repo    repository.TechStack
-	appRepo repository.Application
+	repo    *repository.TechStack
+	appRepo *repository.Application
 }
 
-func NewTechStack(repo repository.TechStack, appRepo repository.Application) TechStack {
+func NewTechStack(repo *repository.TechStack, appRepo *repository.Application) TechStack {
 	return &techStack{repo, appRepo}
 }
 

--- a/pkg/service/trace.go
+++ b/pkg/service/trace.go
@@ -16,10 +16,10 @@ type Trace interface {
 }
 
 type trace struct {
-	repo repository.Trace
+	repo *repository.Trace
 }
 
-func NewTrace(repo repository.Trace) Trace {
+func NewTrace(repo *repository.Trace) Trace {
 	return &trace{repo}
 }
 

--- a/pkg/service/visitor.go
+++ b/pkg/service/visitor.go
@@ -21,11 +21,11 @@ type Visitor interface {
 }
 
 type visitor struct {
-	info  repository.VisitorInfo
-	trace repository.VisitorTrace
+	info  *repository.VisitorInfo
+	trace *repository.VisitorTrace
 }
 
-func NewVisitor(info repository.VisitorInfo, trace repository.VisitorTrace) Visitor {
+func NewVisitor(info *repository.VisitorInfo, trace *repository.VisitorTrace) Visitor {
 	return &visitor{info, trace}
 }
 


### PR DESCRIPTION
This pull request includes several changes to the repository interfaces and their implementations, primarily focusing on converting interface types to struct types and updating the corresponding methods. The most important changes are grouped by file and theme as follows:

### Changes to `MetricsAggregator` and `Router`:

* Converted `appStatRepo` from `repository.ApplicationStat` to `*repository.ApplicationStat` in both `MetricsAggregator` and `Router` constructors and fields. [[1]](diffhunk://#diff-4125040266faf07a2f0bb4ae183108e515c432dfdbc8ed102f3c88ac3011b74eL16-R21) [[2]](diffhunk://#diff-89c68f57c637547b4672d2260481d5b014acad517f06e0e525eda989e722540aL31-R31)

### Changes to `Application` repository:

* Changed `Application` from an interface to a struct and updated its methods to use the struct type instead of the generic type. [[1]](diffhunk://#diff-84a1fce9a5c4abed70f8ccef1daee9ea86f6abc209fabf2f410d3f5fe44386baL13-R21) [[2]](diffhunk://#diff-84a1fce9a5c4abed70f8ccef1daee9ea86f6abc209fabf2f410d3f5fe44386baL47-R38) [[3]](diffhunk://#diff-84a1fce9a5c4abed70f8ccef1daee9ea86f6abc209fabf2f410d3f5fe44386baL63-R54) [[4]](diffhunk://#diff-84a1fce9a5c4abed70f8ccef1daee9ea86f6abc209fabf2f410d3f5fe44386baL84-R75) [[5]](diffhunk://#diff-84a1fce9a5c4abed70f8ccef1daee9ea86f6abc209fabf2f410d3f5fe44386baL101-R92) [[6]](diffhunk://#diff-84a1fce9a5c4abed70f8ccef1daee9ea86f6abc209fabf2f410d3f5fe44386baL118-R109)

### Changes to `ApplicationStat` repository:

* Changed `ApplicationStat` from an interface to a struct and updated its methods to use the struct type instead of the generic type. [[1]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL14-R22) [[2]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL55-R38) [[3]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL71-R54) [[4]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL92-R75) [[5]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL109-R92) [[6]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL126-R109) [[7]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL143-R126) [[8]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL160-R143) [[9]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL177-R160) [[10]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL194-R177) [[11]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL211-R194) [[12]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL228-R211) [[13]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL245-R228) [[14]](diffhunk://#diff-5b49cd2360c6c6d74c920a3311e8d6db9c3b20bbe6ad182550078ae83a27d0abL262-R245)

### Changes to `ApplicationUser` repository:

* Changed `ApplicationUser` from an interface to a struct and updated its methods to use the struct type instead of the generic type. [[1]](diffhunk://#diff-73ef0f8bfe9a00575a03f8ff23105482faf99cfe571b6bee1ebc4c3718d6bd74L13-R21) [[2]](diffhunk://#diff-73ef0f8bfe9a00575a03f8ff23105482faf99cfe571b6bee1ebc4c3718d6bd74L46-R37) [[3]](diffhunk://#diff-73ef0f8bfe9a00575a03f8ff23105482faf99cfe571b6bee1ebc4c3718d6bd74L62-R53) [[4]](diffhunk://#diff-73ef0f8bfe9a00575a03f8ff23105482faf99cfe571b6bee1ebc4c3718d6bd74L83-R74) [[5]](diffhunk://#diff-73ef0f8bfe9a00575a03f8ff23105482faf99cfe571b6bee1ebc4c3718d6bd74L100-R91)

These changes simplify the repository implementations by using concrete types and reduce the complexity associated with generic types.